### PR TITLE
feat: handle unexpected http responses

### DIFF
--- a/main.go
+++ b/main.go
@@ -113,6 +113,9 @@ func (z *zitadel) introspectToken(token string) (tokenInfo, error) {
 	if err != nil {
 		return tokenInfo{}, err
 	}
+	if res.StatusCode != http.StatusOK {
+		return tokenInfo{}, fmt.Errorf("unexpected HTTP code, got :%d", res.StatusCode)
+	}
 	defer res.Body.Close()
 
 	var info tokenInfo


### PR DESCRIPTION
HTTP response codes other than 200 OK where not being handled properly and resulted in pretty cryptic error messages.